### PR TITLE
bugfix

### DIFF
--- a/src/plugins/collapse-groups/plugin.js
+++ b/src/plugins/collapse-groups/plugin.js
@@ -25,7 +25,7 @@ QueryBuilder.define('collapse-groups', function(options) {
 
     // Collapse any groups that were saved as collapsed
     this.on('afterSetRules', function() {
-        $.each($(Selectors.group_container), function(i, el) {
+        $.each(self.$el.find(Selectors.group_container), function(i, el) {
             var group = self.getModel($(el));
             if (group.collapsed) {
                 self.collapse($(el).find('[data-collapse="group"]:first'), options);


### PR DESCRIPTION
When two or more QueryBuilder objects exist, a collapse event on one of them is handled by the others too

**Merge request checklist**

- [x] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [x] I created my branch from `dev` and I am issuing the PR to `dev`
- [ ] I didn't pushed the `dist` directory
- [ ] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
