### PR TITLE
nuova sqlFullFn

### DIFF
--- a/src/plugins/sql-support/plugin.js
+++ b/src/plugins/sql-support/plugin.js
@@ -407,10 +407,16 @@ QueryBuilder.extend(/** @lends module:plugins.SqlSupport.prototype */ {
                      * @returns {string}
                      */
                     var field = self.change('getSQLField', rule.field, rule);
-		    if (sql.ic || rule.data.ignore_case===true) {
-			field = "LOWER("+field+")";
-		    }
-                    var ruleExpression = field + ' ' + sqlFn(value);
+                    if (sql.ic || rule.data.ignore_case===true) {
+                        field = "LOWER("+field+")";
+                    }
+
+                    var ruleExpression;
+                    if (typeof sql.sqlFullFn === 'function' ){
+                        ruleExpression = sql.sqlFullFn(field, value, rule.value);
+                    } else {
+                        ruleExpression = field + ' ' + sqlFn(value);
+                    }
 
                     /**
                      * Modifies the SQL generated for a rule


### PR DESCRIPTION
aggiunta sqlFullFn per una gestione più completa dell'espressione.
sqlFullFn accetta tre parametri:
- field -> il nome del campo
- value -> il valore processato della rule
- ruleValue -> il valore raw preso dalla rule

**Merge request checklist**

- [ ] I read the [guidelines for contributing](https://github.com/mistic100/jQuery-QueryBuilder/blob/master/.github/CONTRIBUTING.md)
- [ ] I created my branch from `dev` and I am issuing the PR to `dev`
- [ ] I didn't pushed the `dist` directory
- [ ] Unit tests are OK
- [ ] If it's a new feature, I added the necessary unit tests
- [ ] If it's a new language, I filled the `__locale` and `__author` fields
